### PR TITLE
make duplicate text outputs to use on different app pages

### DIFF
--- a/R/shiny_models_multicls.R
+++ b/R/shiny_models_multicls.R
@@ -100,7 +100,7 @@ shiny_models.multi_cls_shiny_data <-
             tabName = "static",
             shiny::fluidRow(
               if (length(tune::.get_tune_parameter_names(x$tune_results)) != 0) {
-                h3(shiny::textOutput("selected_config"))
+                h3(shiny::textOutput("selected_perf"))
               },
               boxed(
                 plotly::plotlyOutput("obs_vs_pred"),
@@ -116,7 +116,7 @@ shiny_models.multi_cls_shiny_data <-
             tabName = "interactive",
             shiny::fluidRow(
               if (length(tune::.get_tune_parameter_names(x$tune_results)) != 0) {
-                h3(shiny::textOutput("selected_config"))
+                h3(shiny::textOutput("selected_plots"))
               },
               boxed(
                 plotly::plotlyOutput("pred_vs_numcol"),
@@ -251,7 +251,12 @@ shiny_models.multi_cls_shiny_data <-
           source = "obs"
         ))
       })
-      output$selected_config <- shiny::renderText({
+      # shiny can't re-use the same output in two different UI locations.
+      output$selected_perf <- shiny::renderText({
+        obs_shown(TRUE)
+        display_selected(x, performance, preds, tuning_param, input)
+      })
+      output$selected_plots <- shiny::renderText({
         obs_shown(TRUE)
         display_selected(x, performance, preds, tuning_param, input)
       })

--- a/R/shiny_models_twocls.R
+++ b/R/shiny_models_twocls.R
@@ -94,7 +94,7 @@ shiny_models.two_cls_shiny_data <-
             tabName = "static",
             shiny::fluidRow(
               if (length(tune::.get_tune_parameter_names(x$tune_results)) != 0) {
-                h3(shiny::textOutput("selected_config"))
+                h3(shiny::textOutput("selected_perf"))
               },
               boxed(
                 plotly::plotlyOutput("obs_vs_pred"),
@@ -111,7 +111,7 @@ shiny_models.two_cls_shiny_data <-
             tabName = "interactive",
             shiny::fluidRow(
               if (length(tune::.get_tune_parameter_names(x$tune_results)) != 0) {
-                h3(shiny::textOutput("selected_config"))
+                h3(shiny::textOutput("selected_plots"))
               },
               boxed(
                 plotly::plotlyOutput("pred_vs_numcol"),
@@ -246,7 +246,12 @@ shiny_models.two_cls_shiny_data <-
           source = "obs"
         ))
       })
-      output$selected_config <- shiny::renderText({
+      # shiny can't re-use the same output in two different UI locations.
+      output$selected_perf <- shiny::renderText({
+        obs_shown(TRUE)
+        display_selected(x, performance, preds, tuning_param, input)
+      })
+      output$selected_plots <- shiny::renderText({
         obs_shown(TRUE)
         display_selected(x, performance, preds, tuning_param, input)
       })


### PR DESCRIPTION
In the classification apps, we had two different UI elements that referenced

```r
h3(shiny::textOutput("selected_config"))
```

which is not allowed. 

In R, the `server` function never started up so there was no error message. @cpsievert figured this out but looking at the app in the JS console: 

![image](https://user-images.githubusercontent.com/5731043/140192605-244b1cdc-04a2-4fe0-a683-0caa5c1df2f9.png)

To fix it, an additional output chunk was added with a different ID. 