### PR TITLE
use LazyData to help with dplyr 1.0.8 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,6 +51,6 @@ Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
-LazyData: false
+LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2


### PR DESCRIPTION
Not sure exactly why, but this showed up on `dplyr 1.0.8` revdep checks: 

````
# shinymodels

<details>

* Version: 0.1.0
* GitHub: https://github.com/tidymodels/shinymodels
* Source code: https://github.com/cran/shinymodels
* Date/Publication: 2021-11-17 21:00:02 UTC
* Number of recursive dependencies: 146

Run `cloud_details(, "shinymodels")` for more info

</details>

## Newly broken

*   checking contents of ‘data’ directory ... WARNING
    ```
    Output for data("ames_mlp_itr", package = "shinymodels"):
      Search path was changed
    Output for data("cars_bag_vfld", package = "shinymodels"):
      Search path was changed
    Output for data("cell_race", package = "shinymodels"):
      Search path was changed
    Output for data("scat_fda_bt", package = "shinymodels"):
      Search path was changed
    Output for data("two_class_final", package = "shinymodels"):
      Search path was changed
    ```

## In both

*   checking Rd cross-references ... NOTE
    ```
    Package unavailable to check Rd xrefs: ‘finetune’
    ```
````